### PR TITLE
Removed META-INF files from shaded jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,19 @@
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/MANIFEST.MF</exclude>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
             </plugin>
         </plugins>
         <resources>


### PR DESCRIPTION
This fixes shading warning on both HoloItems and ParadiseCore